### PR TITLE
Use ULL2NUM and NUM2ULL instead of casting

### DIFF
--- a/ext/varint/varint.c
+++ b/ext/varint/varint.c
@@ -6,7 +6,7 @@ static ID getbyte, putbyte;
 static VALUE varint_encode(VALUE module, VALUE io, VALUE int_valV)
 {
     /* unsigned for the bit shifting ops */
-    unsigned long long int_val = (unsigned long long)NUM2LL(int_valV);
+    unsigned long long int_val = NUM2ULL(int_valV);
     unsigned char byte;
     while (1) {
         byte = int_val & 0x7f;
@@ -34,8 +34,7 @@ static VALUE varint_decode(VALUE module, VALUE io)
         int_val |= ((unsigned long long)(byte & 0x7f)) << shift;
         shift += 7;
         if ((byte & 0x80) == 0) {
-            /* return ULL2NUM(int_val); */
-            return LL2NUM((long long)int_val);
+            return ULL2NUM(int_val);
         }
     }
 }


### PR DESCRIPTION
It appears that in rare cases there is an overflow when using a signed long long that prevents the protobuf from decoding. [Here](https://gist.github.com/jeremydurham/152c62e13186314cfacd) is a truncated output of some Varint.decode data to demonstrate the overflow, and I have verified that the after matches VarintPure's behavior.
